### PR TITLE
Remove explicit `object` inheritance

### DIFF
--- a/src/pyBADA/aircraft.py
+++ b/src/pyBADA/aircraft.py
@@ -18,7 +18,7 @@ def checkArgument(argument, **kwargs):
         raise TypeError("Missing " + argument + " argument")
 
 
-class Bada(object):
+class Bada:
     """This class implements the mechanisms applicable across all BADA families."""
 
     def __init__(self):
@@ -183,7 +183,7 @@ class Bada(object):
         return tas * cos(radians(gamma)) + Ws
 
 
-class BadaFamily(object):
+class BadaFamily:
     """This class sets the token for the respected BADA Family."""
 
     def __init__(self, BADA3=False, BADA4=False, BADAH=False, BADAE=False):
@@ -193,7 +193,7 @@ class BadaFamily(object):
         self.BADAE = BADAE
 
 
-class Airplane(object):
+class Airplane:
     """This is a generic airplane class based on a three-degrees-of-freedom point mass model (where all the forces
     are applied at the center of gravity).
 
@@ -315,7 +315,7 @@ class Airplane(object):
         return ESF
 
 
-class Helicopter(object):
+class Helicopter:
     """This is a generic helicopter class based on a Total-Energy Model (TEM)
 
     .. note::this generic class only implements basic aircraft dynamics

--- a/src/pyBADA/bada3.py
+++ b/src/pyBADA/bada3.py
@@ -32,7 +32,7 @@ def checkArgument(argument, **kwargs):
         raise TypeError("Missing " + argument + " argument")
 
 
-class Parser(object):
+class Parser:
     """This class implements the BADA3 parsing mechanism to parse APF, OPF and GPF BADA3 files."""
 
     def __init__(self):

--- a/src/pyBADA/geodesic.py
+++ b/src/pyBADA/geodesic.py
@@ -140,7 +140,7 @@ class Haversine:
         return bearing
 
 
-class Vincenty(object):
+class Vincenty:
     """This class implements the vincenty calculations of geodesics on the ellipsoid-model earth
 
     .. note::
@@ -473,7 +473,7 @@ class Vincenty(object):
         return (dest[0], dest[1])
 
 
-class RhumbLine(object):
+class RhumbLine:
     """This class implements the rhumb line (loxodrome) calculations of geodesics on the ellipsoid-model earth
 
     .. note::
@@ -718,7 +718,7 @@ class RhumbLine(object):
         return decoupled_points
 
 
-class Turn(object):
+class Turn:
     """This class implements the calculations of geodesics turns"""
 
     @staticmethod


### PR DESCRIPTION
Inheriting from `object` is a noop in Python 3 so it can be safely removed.